### PR TITLE
feat: update to use new runner install role

### DIFF
--- a/install_role.tf
+++ b/install_role.tf
@@ -1,4 +1,4 @@
-data "aws_iam_policy_document" "install" {
+data "aws_iam_policy_document" "runner_install" {
   statement {
     effect = "Allow"
     actions = [
@@ -20,12 +20,12 @@ data "aws_iam_policy_document" "install" {
   }
 }
 
-resource "aws_iam_policy" "install" {
-  name   = "${local.prefix}-install"
-  policy = data.aws_iam_policy_document.install.json
+resource "aws_iam_policy" "runner_install" {
+  name   = "${local.prefix}-runner-install"
+  policy = data.aws_iam_policy_document.runner_install.json
 }
 
-data "aws_iam_policy_document" "install_trust" {
+data "aws_iam_policy_document" "runner_install_trust" {
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole", ]
@@ -33,21 +33,21 @@ data "aws_iam_policy_document" "install_trust" {
     principals {
       type = "AWS"
       identifiers = [
-        var.nuon_runner_install_trust_iam_role_arn,
+        var.runner_install_role,
       ]
     }
   }
 }
 
-module "install_iam_role" {
+module "runner_install_iam_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
   version = ">= 5.1.0"
 
   create_role       = true
   role_requires_mfa = false
 
-  role_name                       = "${local.prefix}-install"
+  role_name                       = "${local.prefix}-runner-install"
   create_custom_role_trust_policy = true
-  custom_role_trust_policy        = data.aws_iam_policy_document.install_trust.json
-  custom_role_policy_arns         = [aws_iam_policy.install.arn, ]
+  custom_role_trust_policy        = data.aws_iam_policy_document.runner_install_trust.json
+  custom_role_policy_arns         = [aws_iam_policy.runner_install.arn, ]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,7 +2,7 @@ output "runner" {
   value = {
     runner_iam_role_arn  = module.runner_iam_role.iam_role_arn
     odr_iam_role_arn     = module.odr_iam_role.iam_role_arn
-    install_iam_role_arn = module.install_iam_role.iam_role_arn
+    install_iam_role_arn = module.runner_install_iam_role.iam_role_arn
   }
   description = "A map of runner attributes: runner_iam_role_arn, odr_iam_role_arn, install_iam_role_arn"
 }

--- a/runner_role.tf
+++ b/runner_role.tf
@@ -8,15 +8,15 @@ data "aws_iam_policy_document" "runner" {
   statement {
     effect = "Allow"
     actions = [
-    "iam:GetRole",
-    "iam:PassRole"
+      "iam:GetRole",
+      "iam:PassRole"
     ]
     resources = ["*"]
   }
 
   statement {
-    effect = "Allow"
-    actions = ["ecs:*"]
+    effect    = "Allow"
+    actions   = ["ecs:*"]
     resources = ["*"]
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -50,9 +50,9 @@ variable "public_root_domain" {
   description = "The public root domain of the sandbox. Will be set by Nuon during the install provision process."
 }
 
-variable "nuon_runner_install_trust_iam_role_arn" {
+variable "runner_install_role" {
   type        = string
-  description = "The ARN of the AWS IAM Role to grant Nuon access to install the ECS Fargate runner. Will be set by Nuon during the install provision process."
+  description = "The role that is used to install the runner, and should be granted access."
 }
 
 variable "private_subnet_ids" {


### PR DESCRIPTION
replaces the `nuon_runner_install_trust_iam_role_arn` with `runner_install_role`